### PR TITLE
Added AdditionalDLLs and BuildDir

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # Yaraizen.PlateUp.ModBuildUtilities
 
-| Property				| Type		| Description |
-| ---					| ---		| --- |
-| GamePath				| String	| The directory where the PlateUp executable is located |
-| WorkshopPath			| String	| Your PlateUp workshop directory |
-| AssemblyReferencePath | String	| Your PlateUp_Data/Managed directory |
+| Property				| Type		| Description                                                              |
+| ---					| ---		|--------------------------------------------------------------------------|
+| GamePath				| String	| The directory where the PlateUp executable is located                    |
+| WorkshopPath			| String	| Your PlateUp workshop directory                                          |
+| AssemblyReferencePath | String	| Your PlateUp_Data/Managed directory                                      |
 | GameModsPath			| String	| The Mods folder located in the same directory as your PlateUp executable |
-| AssetBundlePath		| String	| The path to the AssetBundle for your mod |
-| ThirdPartyPath		| String	| The path to third party dlls for your mod |
+| AssetBundlePath		| String	| The path to the AssetBundle for your mod                                 |
+| ThirdPartyPath		| String	| The path to third party dlls for your mod                                |
+| BuildDir		| String	| The path that your IDE exports dlls to                                   |
 
 | Utility				| Type		| Default	| Description |
 | ---					| ---		| ---		| --- |
@@ -60,4 +61,18 @@ Blacklist with wild card and exclude
 <ItemGroup>
 	<Blacklist Include="$(AssemblyReferencePath)\Unity*.dll" Exclude="$(AssemblyReferencePath)\Unity.Entities.dll" />
 <\ItemGroup>
+```
+
+# Additional DLLs
+
+You can include additional DLLs to be copied to your build directory. Make a new ItemGroup and include a Additional item with the DLL you wish to include.
+
+### Example
+
+```xml
+<ItemGroup>
+    <Additional Include="$(BuildDir)\0Harmony.dll" />
+    <Additional Include="$(BuildDir)\KitchenLib-Workshop.dll" />
+    <Additional Include="$D:\Foo\Bar\Foobar.dll" />
+</ItemGroup>
 ```

--- a/package.targets
+++ b/package.targets
@@ -71,6 +71,7 @@
 	<PropertyGroup Condition="'$(EnableDocumentation)'">
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<DocumentationFile>bin\$(Configuration)/$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+		<BuildDir>$(ProjectDir)/bin/$(Configuration)/$(TargetFramework)/</BuildDir>
 	</PropertyGroup>
 		
 	<Target Name="Deploy" AfterTargets="Build" Condition="$(EnableModDeployLocal) == 'true'">
@@ -81,13 +82,14 @@
 
 		<ItemGroup>
 			<_IncludeDLL Include="$(ThirdPartyPath)/*.dll" />
-			<_DLLToCopy Include="$(ProjectDir)/bin/$(Configuration)/$(TargetFramework)/*.dll" />
-			<_XMLToCopy Include="$(ProjectDir)/bin/$(Configuration)/$(TargetFramework)/$(AssemblyName).xml" />
-			<_PDBToCopy Include="$(ProjectDir)/bin/$(Configuration)/$(TargetFramework)/$(AssemblyName).pdb" />
+			<_DLLToCopy Include="$(BuildDir)/$(AssemblyName).dll" />
+			<_XMLToCopy Include="$(BuildDir)/$(AssemblyName).xml" />
+			<_PDBToCopy Include="$(BuildDir)/$(AssemblyName).pdb" />
 		</ItemGroup>
 
 		<Copy SourceFiles="@(_IncludeDLL)" DestinationFolder="@(_IncludeDLL->'$(GameModsPath)\$(MSBuildProjectName)\content\%(RecursiveDir)%(Filename)%(Extension)')" />
 		<Copy SourceFiles="@(_DLLToCopy)" DestinationFiles="@(_DLLToCopy->'$(GameModsPath)\$(MSBuildProjectName)\content\%(RecursiveDir)%(Filename)%(Extension)')" />
+		<Copy SourceFiles="@(AdditionalDLLs)" DestinationFiles="@(AdditionalDLLs->'$(GameModsPath)\$(MSBuildProjectName)\content\%(RecursiveDir)%(Filename)%(Extension)')" />
 		<Copy Condition="Exists('$(AssetBundlePath)')" SourceFiles="$(AssetBundlePath)" DestinationFiles="$(GameModsPath)\$(MSBuildProjectName)\content\$([System.String]::Copy('$(MSBuildProjectName)').ToLower()).assets" />
 		<Copy Condition="'$(EnableDocumentation)'" SourceFiles="@(_XMLToCopy)" DestinationFiles="@(_XMLToCopy->'$(GameModsPath)\$(MSBuildProjectName)\content\%(RecursiveDir)%(Filename)%(Extension)')" />
 		<Copy Condition="'$(EnableAutoPDB)'" SourceFiles="@(_PDBToCopy)" DestinationFiles="@(_PDBToCopy->'$(GameModsPath)\$(MSBuildProjectName)\content\%(RecursiveDir)%(Filename)%(Extension)')" />


### PR DESCRIPTION
Adds `BuildDir` for an easier reference to the IDEs output directory. Adds `AdditionalDLLs` to include DLLs when copying to the content directory.